### PR TITLE
Bundle `pdfjs-dist` into `pdf-core`

### DIFF
--- a/packages/pdf-core/package.json
+++ b/packages/pdf-core/package.json
@@ -26,7 +26,7 @@
     "lint:fix": "eslint . --fix",
     "lint:strict": "eslint . --max-warnings 0"
   },
-  "peerDependencies": {
+  "dependencies": {
     "pdfjs-dist": "^5.2.133"
   },
   "devDependencies": {
@@ -34,7 +34,6 @@
     "@tspdf/rollup-config": "*",
     "@tspdf/typescript-config": "*",
     "eslint": "^9.28.0",
-    "pdfjs-dist": "^5.2.133",
     "rollup": "^4.40.2",
     "typescript": "^5.8.3"
   }

--- a/packages/pdf-core/rollup.config.mjs
+++ b/packages/pdf-core/rollup.config.mjs
@@ -9,7 +9,7 @@ const licenseFile = resolve(__dirname, '../../licenses/pdfjs-dist.txt');
 const pdfCoreConfig = await createTypeScriptLibraryConfig({
   input: 'src/index.ts',
   packageJsonPath: './package.json',
-  minify: false,
+  minify: true,
   filename: 'index.esm.js',
   plugins: [
     copy({

--- a/packages/pdf-core/rollup.config.mjs
+++ b/packages/pdf-core/rollup.config.mjs
@@ -1,16 +1,50 @@
 import { createTypeScriptLibraryConfig } from '@tspdf/rollup-config/ts-internal';
+import { dirname, resolve } from 'path';
+import copy from 'rollup-plugin-copy';
+import { fileURLToPath } from 'url';
 
-const pdfCoreConfig = createTypeScriptLibraryConfig({
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const licenseFile = resolve(__dirname, '../../licenses/pdfjs-dist.txt');
+
+const pdfCoreConfig = await createTypeScriptLibraryConfig({
   input: 'src/index.ts',
   packageJsonPath: './package.json',
-  minify: true,
+  minify: false,
   filename: 'index.esm.js',
+  plugins: [
+    copy({
+      targets: [
+        {
+          src: licenseFile,
+          dest: 'dist/pdfjs-dist',
+          rename: 'LICENSE-pdfjs-dist.txt',
+        },
+      ],
+      hook: 'writeBundle',
+    }),
+  ],
 });
 
 // Add manual chunks for pdfjs-dist
 if (pdfCoreConfig[0] && pdfCoreConfig[0].output) {
   pdfCoreConfig[0].output.manualChunks = {
-    pdfjs: ['pdfjs-dist'],
+    'pdfjs-dist/index.esm': ['pdfjs-dist'],
+  };
+
+  // Override chunk file naming to use .js extension consistently
+  pdfCoreConfig[0].output.chunkFileNames = '[name].js';
+
+  // Remove paths mapping since this IS the pdf-core package
+  delete pdfCoreConfig[0].output.paths;
+
+  // Override external to not externalize @tspdf/pdf-core since this IS pdf-core
+  const originalExternal = pdfCoreConfig[0].external;
+  pdfCoreConfig[0].external = id => {
+    // Don't externalize @tspdf/pdf-core since this is the pdf-core package
+    if (id.includes('@tspdf/pdf-core')) {
+      return false;
+    }
+    return originalExternal(id);
   };
 }
 

--- a/packages/pdf-core/rollup.config.mjs
+++ b/packages/pdf-core/rollup.config.mjs
@@ -7,4 +7,11 @@ const pdfCoreConfig = createTypeScriptLibraryConfig({
   filename: 'index.esm.js',
 });
 
+// Add manual chunks for pdfjs-dist
+if (pdfCoreConfig[0] && pdfCoreConfig[0].output) {
+  pdfCoreConfig[0].output.manualChunks = {
+    pdfjs: ['pdfjs-dist'],
+  };
+}
+
 export default pdfCoreConfig;

--- a/packages/pdf-core/rollup.config.mjs
+++ b/packages/pdf-core/rollup.config.mjs
@@ -38,10 +38,15 @@ if (pdfCoreConfig[0] && pdfCoreConfig[0].output) {
   delete pdfCoreConfig[0].output.paths;
 
   // Override external to not externalize @tspdf/pdf-core since this IS pdf-core
+  // Also don't externalize pdfjs-dist since we want to bundle it here
   const originalExternal = pdfCoreConfig[0].external;
   pdfCoreConfig[0].external = id => {
     // Don't externalize @tspdf/pdf-core since this is the pdf-core package
     if (id.includes('@tspdf/pdf-core')) {
+      return false;
+    }
+    // Don't externalize pdfjs-dist since we want to bundle it in pdf-core
+    if (id === 'pdfjs-dist') {
       return false;
     }
     return originalExternal(id);

--- a/packages/react-pdf/README.md
+++ b/packages/react-pdf/README.md
@@ -2,10 +2,10 @@
 
 ## Dependencies
 
-This package uses PDF.js (via @tspdf/pdf-core) under the Apache 2.0 License for PDF rendering capabilities.
+This package includes PDF.js (via @tspdf/pdf-core) under the Apache 2.0 License for PDF rendering capabilities.
 
 ## License
 
 This package is licensed under the MIT License. See the [LICENSE](../../LICENSE) file for details.
 
-PDF.js dependency is licensed under the Apache 2.0 License. See [licenses/pdfjs-dist.txt](../../licenses/pdfjs-dist.txt) for the full license text.
+PDF.js dependency is bundled and licensed under the Apache 2.0 License. See [dist/licenses/pdfjs-dist.txt](dist/licenses/pdfjs-dist.txt) for the full license text.

--- a/packages/react-pdf/package.json
+++ b/packages/react-pdf/package.json
@@ -12,7 +12,7 @@
     {
       "type": "Apache-2.0",
       "url": "https://github.com/tspdf/tspdf/blob/main/licenses/pdfjs-dist.txt",
-      "note": "PDF.js dependency"
+      "note": "PDF.js dependency (bundled)"
     }
   ],
   "type": "module",
@@ -34,7 +34,6 @@
     "lint:strict": "eslint . --max-warnings 0"
   },
   "peerDependencies": {
-    "pdfjs-dist": "^5.2.133",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/packages/react-pdf/rollup.config.mjs
+++ b/packages/react-pdf/rollup.config.mjs
@@ -1,26 +1,10 @@
 import { createReactLibraryConfig } from '@tspdf/rollup-config/react-internal';
-import { dirname, resolve } from 'path';
-import copy from 'rollup-plugin-copy';
-import { fileURLToPath } from 'url';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const licenseFile = resolve(__dirname, '../../licenses/pdfjs-dist.txt');
-
-const reactPdfConfig = createReactLibraryConfig({
+const reactPdfConfig = await createReactLibraryConfig({
   input: 'src/index.tsx',
   packageJsonPath: './package.json',
-  minify: true,
-  plugins: [
-    copy({
-      targets: [
-        {
-          src: licenseFile,
-          dest: 'dist/licenses',
-        },
-      ],
-      hook: 'writeBundle',
-    }),
-  ],
+  minify: false,
+  copyPdfCore: true,
 });
 
 export default reactPdfConfig;

--- a/packages/react-pdf/rollup.config.mjs
+++ b/packages/react-pdf/rollup.config.mjs
@@ -3,7 +3,7 @@ import { createReactLibraryConfig } from '@tspdf/rollup-config/react-internal';
 const reactPdfConfig = await createReactLibraryConfig({
   input: 'src/index.tsx',
   packageJsonPath: './package.json',
-  minify: false,
+  minify: true,
   copyPdfCore: true,
 });
 

--- a/packages/rollup-config/base.js
+++ b/packages/rollup-config/base.js
@@ -33,7 +33,7 @@ export function createBaseConfig(options) {
     esbuild({
       target,
       minify,
-      sourcemap: true,
+      sourcemap: false,
       jsx: 'automatic',
       define: {
         'process.env.NODE_ENV': JSON.stringify(

--- a/packages/rollup-config/react-internal.js
+++ b/packages/rollup-config/react-internal.js
@@ -36,8 +36,7 @@ export function createReactLibraryConfig(options) {
       'react',
       'react-dom',
       'react/jsx-runtime',
-      'pdfjs-dist',
-      // Don't externalize @tspdf packages - bundle them
+      // Don't externalize @tspdf packages or pdfjs-dist - bundle them
       ...external.filter(ext => !ext.startsWith('@tspdf/')),
     ];
   }

--- a/packages/rollup-config/ts-internal.js
+++ b/packages/rollup-config/ts-internal.js
@@ -35,16 +35,17 @@ export function createTypeScriptLibraryConfig(options) {
     {
       input: resolvedInput,
       output: {
-        file: `${outDir}/${filename}`,
+        dir: outDir,
         format: 'es',
         sourcemap: true,
-        inlineDynamicImports: true,
+        entryFileNames: filename,
+        chunkFileNames: '[name].js',
       },
       plugins: [...basePlugins],
       external: id => {
         // Bundle @tspdf packages, externalize everything else that's not relative
         if (id.startsWith('@tspdf/')) return false;
-        if (id === 'pdfjs-dist') return true;
+        if (id === 'pdfjs-dist') return false; // Bundle pdfjs-dist
         return !id.startsWith('.') && !id.startsWith('/');
       },
       treeshake: {

--- a/packages/rollup-config/ts-internal.js
+++ b/packages/rollup-config/ts-internal.js
@@ -1,3 +1,6 @@
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
 import {
   createBaseConfig,
   createTypeScriptDeclarationsConfig,
@@ -7,7 +10,7 @@ import {
  * Create TypeScript library configuration for internal packages
  * ESM-only format optimized for tree-shaking
  */
-export function createTypeScriptLibraryConfig(options) {
+export async function createTypeScriptLibraryConfig(options) {
   const {
     input,
     packageJsonPath,
@@ -16,7 +19,30 @@ export function createTypeScriptLibraryConfig(options) {
     target = 'es2024',
     filename = 'index.js',
     plugins = [],
+    additionalExternals = [],
+    copyPdfCore = false,
   } = options;
+
+  // Handle pdf-core copying if requested
+  let allPlugins = [...plugins];
+  if (copyPdfCore) {
+    // Dynamic import of copy plugin to avoid loading if not needed
+    const copy = await import('rollup-plugin-copy').then(m => m.default);
+    const __dirname = dirname(fileURLToPath(import.meta.url));
+    const pdfCoreDistPath = resolve(__dirname, '../pdf-core/dist');
+
+    allPlugins.push(
+      copy({
+        targets: [
+          {
+            src: `${pdfCoreDistPath}/*`,
+            dest: 'dist/pdf-core',
+          },
+        ],
+        hook: 'writeBundle',
+      }),
+    );
+  }
 
   // Get base configuration
   const baseConfig = createBaseConfig({
@@ -25,7 +51,7 @@ export function createTypeScriptLibraryConfig(options) {
     outputDir,
     minify,
     target,
-    plugins,
+    plugins: allPlugins,
   });
 
   const { resolvedInput, basePlugins, outputDir: outDir } = baseConfig;
@@ -39,11 +65,37 @@ export function createTypeScriptLibraryConfig(options) {
         format: 'es',
         sourcemap: false,
         entryFileNames: filename,
-        chunkFileNames: '[name].js',
+        chunkFileNames: chunkInfo => {
+          // Place @tspdf/pdf-core chunks in pdf-core folder
+          if (
+            chunkInfo.facadeModuleId?.includes('@tspdf/pdf-core') ||
+            chunkInfo.moduleIds.some(id => id.includes('@tspdf/pdf-core'))
+          ) {
+            return 'pdf-core/[name].js';
+          }
+          return '[name].js';
+        },
+        manualChunks: id => {
+          // Create a separate chunk for @tspdf/pdf-core
+          if (id.includes('@tspdf/pdf-core')) {
+            return 'pdf-core';
+          }
+        },
+        paths: {
+          '@tspdf/pdf-core': './pdf-core/index.esm.js',
+        },
       },
       plugins: [...basePlugins],
       external: id => {
-        // Bundle @tspdf packages, externalize everything else that's not relative
+        // Always externalize @tspdf/pdf-core
+        if (id.includes('@tspdf/pdf-core')) {
+          return true;
+        }
+        // Check additional externals
+        if (additionalExternals.includes(id)) {
+          return true;
+        }
+        // Bundle other @tspdf packages
         if (id.startsWith('@tspdf/')) return false;
         if (id === 'pdfjs-dist') return false; // Bundle pdfjs-dist
         return !id.startsWith('.') && !id.startsWith('/');

--- a/packages/rollup-config/ts-internal.js
+++ b/packages/rollup-config/ts-internal.js
@@ -97,7 +97,8 @@ export async function createTypeScriptLibraryConfig(options) {
         }
         // Bundle other @tspdf packages
         if (id.startsWith('@tspdf/')) return false;
-        if (id === 'pdfjs-dist') return false; // Bundle pdfjs-dist
+        // Externalize pdfjs-dist by default (can be overridden in specific packages)
+        if (id === 'pdfjs-dist') return true;
         return !id.startsWith('.') && !id.startsWith('/');
       },
       treeshake: {

--- a/packages/rollup-config/ts-internal.js
+++ b/packages/rollup-config/ts-internal.js
@@ -37,7 +37,7 @@ export function createTypeScriptLibraryConfig(options) {
       output: {
         dir: outDir,
         format: 'es',
-        sourcemap: true,
+        sourcemap: false,
         entryFileNames: filename,
         chunkFileNames: '[name].js',
       },

--- a/packages/rollup-config/ts-internal.js
+++ b/packages/rollup-config/ts-internal.js
@@ -108,7 +108,23 @@ export async function createTypeScriptLibraryConfig(options) {
       },
     },
 
-    // TypeScript declarations
-    createTypeScriptDeclarationsConfig(resolvedInput, outDir),
+    // TypeScript declarations with path mapping
+    {
+      ...createTypeScriptDeclarationsConfig(resolvedInput, outDir),
+      external: id => {
+        // Externalize @tspdf/pdf-core in declarations
+        if (id.includes('@tspdf/pdf-core')) {
+          return true;
+        }
+        // Use default externals
+        return /\.css$/.test(id) || /node_modules/.test(id);
+      },
+      output: {
+        ...createTypeScriptDeclarationsConfig(resolvedInput, outDir).output,
+        paths: {
+          '@tspdf/pdf-core': './pdf-core',
+        },
+      },
+    },
   ];
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4213,8 +4213,6 @@ __metadata:
     pdfjs-dist: "npm:^5.2.133"
     rollup: "npm:^4.40.2"
     typescript: "npm:^5.8.3"
-  peerDependencies:
-    pdfjs-dist: ^5.2.133
   languageName: unknown
   linkType: soft
 
@@ -4233,7 +4231,6 @@ __metadata:
     rollup: "npm:^4.40.2"
     typescript: "npm:^5.8.3"
   peerDependencies:
-    pdfjs-dist: ^5.2.133
     react: ^19.1.0
     react-dom: ^19.1.0
   languageName: unknown


### PR DESCRIPTION
- Added logic to manage all `pdfjs-dist` related code in `@tspdf/pdf-core` package. Include license files.
- Added logic to correctly copy and bundle the entire `pdf-core` dist into the `react-pdf` dist.